### PR TITLE
Prevent show `nbsp` when empty selling price

### DIFF
--- a/src/grid/PartGridView.php
+++ b/src/grid/PartGridView.php
@@ -237,6 +237,7 @@ class PartGridView extends BoxedGridView
                 'footer' => '<b>' . Yii::t('hipanel:stock', 'TOTAL on screen') . '</b>',
             ],
             'selling_price' => [
+                'format' => 'raw',
                 'filterAttribute' => 'selling_currency',
                 'filter' => false,
                 'value' => function ($model) {


### PR DESCRIPTION
When no selling_price it is shown as `&nbsp;`