### PR TITLE
HP-1596: add filter by remaining warrenty months, fill the warranty i…

### DIFF
--- a/src/grid/ModelColumn.php
+++ b/src/grid/ModelColumn.php
@@ -13,16 +13,9 @@ use Yii;
 
 class ModelColumn extends MainColumn
 {
-    public function init()
+    public function init(): void
     {
         parent::init();
-
-        $this->attribute = 'model';
-        $this->prepareValue();
-    }
-    
-    private function prepareValue(): void
-    {
         $this->value = function (Part $model): string {
             $modelLabel = Html::encode($model->model_label);
             if (Yii::$app->user->can('model.read')) {
@@ -31,6 +24,7 @@ class ModelColumn extends MainColumn
             if (isset($model->warranty_till)) {
                 $modelLabel .= $this->getWarrantyLabel($model);
             }
+
             return $modelLabel;
         };
     }
@@ -48,6 +42,7 @@ class ModelColumn extends MainColumn
         if (!is_numeric($diff)) {
             $color = 'danger';
         }
+
         return Label::widget(['label' => $diff, 'tag' => 'sup', 'color' => $color]);
     }
 }

--- a/src/grid/PartGridView.php
+++ b/src/grid/PartGridView.php
@@ -16,7 +16,6 @@ use hipanel\grid\BoxedGridView;
 use hipanel\grid\CurrencyColumn;
 use hipanel\grid\RefColumn;
 use hipanel\modules\client\grid\ClientColumn;
-use hipanel\modules\stock\grid\ModelColumn;
 use hipanel\modules\stock\helpers\ProfitColumns;
 use hipanel\modules\stock\models\Move;
 use hipanel\modules\stock\models\Part;
@@ -96,6 +95,7 @@ class PartGridView extends BoxedGridView
             ],
             'model' => [
                 'class' => ModelColumn::class,
+                'attribute' => 'model',
                 'format' => 'raw',
                 'label' => Yii::t('hipanel:stock', 'Model'),
             ],
@@ -108,9 +108,6 @@ class PartGridView extends BoxedGridView
                 'value' => function ($model) {
                     return $model->model_type_label;
                 },
-            ],
-            'warranty_till' => [
-
             ],
             'model_type_label' => [
                 'class' => RefColumn::class,
@@ -342,6 +339,11 @@ class PartGridView extends BoxedGridView
 
                     return '';
                 }
+            ],
+            'warranty_till' => [
+                'class' => WarrantyColumn::class,
+                'attribute' => 'warranty_till',
+                'format' => ['datetime', 'php:Y-m-d'],
             ],
         ]);
     }

--- a/src/grid/WarrantyColumn.php
+++ b/src/grid/WarrantyColumn.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace hipanel\modules\stock\grid;
+
+use hipanel\grid\DataColumn;
+
+class WarrantyColumn extends DataColumn
+{
+    public function init(): void
+    {
+        parent::init();
+        $this->filter = '';
+    }
+}

--- a/src/models/PartSearch.php
+++ b/src/models/PartSearch.php
@@ -18,7 +18,7 @@ use Yii;
 class PartSearch extends Part
 {
     use SearchModelTrait {
-        searchAttributes as defaultSearchAttributes;
+        SearchModelTrait::searchAttributes as defaultSearchAttributes;
     }
 
     public function searchAttributes()

--- a/src/views/part/_form.php
+++ b/src/views/part/_form.php
@@ -14,11 +14,26 @@ use hipanel\widgets\DynamicFormWidget;
 use yii\bootstrap\ActiveForm;
 use yii\helpers\Html;
 use yii\helpers\Url;
+use yii\web\View;
 
 /**
  * @var Part $model
  * @var array $currencyTypes
  */
+
+$this->registerJs(/** @lang JavaScript */ <<<JS
+(() => {
+  $(document).on("select2:select", "[id$='partno']", function (event) {
+    const datetimePlugin = $(event.target).parents(".item").find("[id$='warranty_till']").parent().data('datetimepicker');
+    const { warranty_months } = event.params.data;
+    if (warranty_months) {
+      datetimePlugin.setDate(moment().add(3, 'months').toDate());
+    }
+  });
+})();
+JS
+    ,
+    View::POS_LOAD);
 
 ?>
 <?php $form = ActiveForm::begin([
@@ -91,7 +106,9 @@ use yii\helpers\Url;
                         <?php if ($model->dst_id) : ?>
                             <?= $form->field($model, "[$i]dst_id")->widget(PartDestinationCombo::class, ['name' => 'dst_id']) ?>
                         <?php else : ?>
-                            <?= $form->field($model, "[$i]dst_ids", ['options' => ['class' => 'required']])->widget(PartDestinationCombo::class, [
+                            <?= $form->field($model,
+                                "[$i]dst_ids",
+                                ['options' => ['class' => 'required']])->widget(PartDestinationCombo::class, [
                                 'primaryFilter' => 'name_inilike',
                                 'hasId' => true,
                                 'multiple' => true,
@@ -108,7 +125,8 @@ use yii\helpers\Url;
                     <div class="col-md-6">
                         <div class="row">
                             <div class="col-md-12">
-                                <?= $form->field($model, "[$i]serials")->hint(Yii::t('hipanel:stock', 'In order to use the automatic serials generation, the field should look like: <samp>[number of generated serials]_</samp>')) ?>
+                                <?= $form->field($model, "[$i]serials")->hint(Yii::t('hipanel:stock',
+                                    'In order to use the automatic serials generation, the field should look like: <samp>[number of generated serials]_</samp>')) ?>
                             </div>
                             <div class="col-md-12">
                                 <?= $form->field($model, "[$i]move_descr") ?>
@@ -120,7 +138,9 @@ use yii\helpers\Url;
                                         'items' => $this->context->getCurrencyTypes(),
                                     ],
                                 ]) ?>
-                                <?= $form->field($model, "[$i]currency", ['template' => '{input}{error}'])->hiddenInput(['data-amount-with-currency' => 'currency']) ?>
+                                <?= $form->field($model,
+                                    "[$i]currency",
+                                    ['template' => '{input}{error}'])->hiddenInput(['data-amount-with-currency' => 'currency']) ?>
                             </div>
                             <div class="col-md-6">
                                 <?= $form->field($model, "[$i]company_id")->widget(CompanyCombo::class) ?>
@@ -129,37 +149,42 @@ use yii\helpers\Url;
                     </div>
                 <?php else : ?>
                     <div class="col-md-12">
-                        <div class="col-md-6">
-                            <?= $form->field($model, "[$i]model_id")->widget(ModelCombo::class) ?>
-                        </div>
-                        <div class="col-md-3">
-                            <?= $form->field($model, "[$i]dst_name")->textInput(['disabled' => true])->label(Yii::t('hipanel:stock', 'Location')) ?>
-                        </div>
-                        <div class="col-md-3">
-                            <?= $form->field($model, "[$i]serial") ?>
+                        <div class="row">
+                            <div class="col-md-6">
+                                <?= $form->field($model, "[$i]model_id")->widget(ModelCombo::class) ?>
+                            </div>
+                            <div class="col-md-3">
+                                <?= $form->field($model, "[$i]dst_name")->textInput(['disabled' => true])->label(Yii::t('hipanel:stock',
+                                    'Location')) ?>
+                            </div>
+                            <div class="col-md-3">
+                                <?= $form->field($model, "[$i]serial") ?>
+                            </div>
                         </div>
                     </div>
                     <div class="col-md-12">
-                        <div class="col-md-3">
-                            <?= $form->field($model, "[$i]warranty_till")->widget(DateTimePicker::class, [
-                                'clientOptions' => [
-                                    'format' => 'yyyy-mm-dd',
-                                    'minView' => 2,
-                                    'todayHighlight' => true,
-                                ],
-                            ]) ?>
-                        </div>
-                        <div class="col-md-3">
-                            <?= $form->field($model, "[$i]company_id")->widget(CompanyCombo::class) ?>
-                        </div>
-                        <div class="col-md-6 <?= AmountWithCurrency::$widgetClass ?>">
-                            <?= $form->field($model, "[$i]price")->widget(AmountWithCurrency::class, [
-                                'currencyAttributeName' => "[$i]currency",
-                                'currencyAttributeOptions' => [
-                                    'items' => $currencyTypes,
-                                ],
-                            ]) ?>
-                            <?= $form->field($model, "[$i]currency", ['template' => '{input}{error}'])->hiddenInput() ?>
+                        <div class="row">
+                            <div class="col-md-3">
+                                <?= $form->field($model, "[$i]warranty_till")->widget(DateTimePicker::class, [
+                                    'clientOptions' => [
+                                        'format' => 'yyyy-mm-dd',
+                                        'minView' => 2,
+                                        'todayHighlight' => true,
+                                    ],
+                                ]) ?>
+                            </div>
+                            <div class="col-md-3">
+                                <?= $form->field($model, "[$i]company_id")->widget(CompanyCombo::class) ?>
+                            </div>
+                            <div class="col-md-6 <?= AmountWithCurrency::$widgetClass ?>">
+                                <?= $form->field($model, "[$i]price")->widget(AmountWithCurrency::class, [
+                                    'currencyAttributeName' => "[$i]currency",
+                                    'currencyAttributeOptions' => [
+                                        'items' => $currencyTypes,
+                                    ],
+                                ]) ?>
+                                <?= $form->field($model, "[$i]currency", ['template' => '{input}{error}'])->hiddenInput() ?>
+                            </div>
                         </div>
                     </div>
                     <div class="col-md-12">

--- a/src/views/part/_form.php
+++ b/src/views/part/_form.php
@@ -27,7 +27,7 @@ $this->registerJs(/** @lang JavaScript */ <<<JS
     const datetimePlugin = $(event.target).parents(".item").find("[id$='warranty_till']").parent().data('datetimepicker');
     const { warranty_months } = event.params.data;
     if (warranty_months) {
-      datetimePlugin.setDate(moment().add(3, 'months').toDate());
+      datetimePlugin.setDate(moment().add(warranty_months, 'months').toDate());
     }
   });
 })();

--- a/src/views/part/_search.php
+++ b/src/views/part/_search.php
@@ -9,6 +9,7 @@ use hipanel\modules\stock\widgets\combo\OrderCombo;
 use hipanel\modules\stock\widgets\combo\PartCombo;
 use hipanel\modules\stock\widgets\combo\PartnoCombo;
 use hipanel\modules\stock\widgets\StockLocationsListTreeSelect;
+use hipanel\modules\stock\widgets\WarrantyMonthsRangeInput;
 use hipanel\widgets\AdvancedSearch;
 use hiqdev\combo\StaticCombo;
 use hipanel\widgets\RefCombo;
@@ -171,6 +172,10 @@ JS
 
     <div class="col-md-4 col-sm-6 col-xs-12">
         <?= $search->field('order_name_ilike') ?>
+    </div>
+
+    <div class="col-md-4 col-sm-6 col-xs-12">
+        <?= $search->field('warranty_till')->widget(WarrantyMonthsRangeInput::class) ?>
     </div>
 <?php endif ?>
 

--- a/src/widgets/StockLocationsListTreeSelect.php
+++ b/src/widgets/StockLocationsListTreeSelect.php
@@ -82,7 +82,7 @@ CSS);
                   :multiple="true"
                   value-consists-of="BRANCH_PRIORITY"
                   delimiter=","
-                  auto-select-ancestors="true"
+                  :auto-select-ancestors="true"
                   :clearable="false"
                   :allow-selecting-disabled-descendants="true"
                   search-nested

--- a/src/widgets/WarrantyMonthsRangeInput.php
+++ b/src/widgets/WarrantyMonthsRangeInput.php
@@ -35,7 +35,7 @@ class WarrantyMonthsRangeInput extends InputWidget
               const from = fromInput.val();
               const till = tillInput.val();
               const value = [from, till];
-             \$("#$inputId").val(value.join(",", value));
+             \$("#$inputId").val(value.join(","));
             });
           })();
 

--- a/src/widgets/WarrantyMonthsRangeInput.php
+++ b/src/widgets/WarrantyMonthsRangeInput.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace hipanel\modules\stock\widgets;
+
+use Yii;
+use yii\helpers\Html;
+use yii\widgets\InputWidget;
+
+class WarrantyMonthsRangeInput extends InputWidget
+{
+    public ?string $hint = null;
+
+    public function run(): string
+    {
+        $widgetId = $this->getId();
+        $inputId = $this->options['id'];
+        if (str_contains((string)$this->model->{$this->attribute}, ',')) {
+            [$from, $till] = explode(',', $this->model->{$this->attribute});
+        } else {
+            $this->model->{$this->attribute} = null;
+        }
+        $hiddenInput = $this->hasModel()
+            ? Html::activeHiddenInput($this->model, $this->attribute, $this->options)
+            : Html::hiddenInput($this->name, $this->value, $this->options);
+        $fromInput = $this->createInput('warranty_from', Yii::t('hipanel:stock', 'Warranty from'), $from ?? '');
+        $tillInput = $this->createInput('warranty_till', Yii::t('hipanel:stock', 'Warranty till'), $till ?? '');
+        $hint = Yii::t('hipanel:stock', "Enter a range of months in numeric format, where 0 is the current month, -1 the previous month and 1 the next month.");
+        $this->view->registerJs(/** @lang JavaScript */ <<<"JS"
+          ;(() => {
+            const fromInput = \$("#$widgetId input[name$='from']");
+            const tillInput = \$("#$widgetId input[name$='till']");
+            \$("#$widgetId input[type!='hidden']").on("change", function (event) {
+              const from = fromInput.val();
+              const till = tillInput.val();
+              const value = [from, till];
+             \$("#$inputId").val(value.join(",", value));
+            });
+          })();
+
+JS
+        );
+
+        return <<<HTML
+            <div id="$widgetId" style="display: flex;">
+                $fromInput
+                <span style="display: inline-block; width: 24px; line-height: 32px; text-align: center;">-</span>
+                $tillInput
+            </div>
+            <div style="color: rgba(0, 0, 0, 0.45)">$hint</div>
+            $hiddenInput
+HTML;
+    }
+
+    private function createInput(string $attribute, string $label, string $value): string
+    {
+        return Html::input('number', $attribute, $value, [
+            'class' => 'form-control',
+            'placeholder' => $label,
+            'min' => -999,
+            'max' => 999,
+            'step' => 1,
+            'style' => [
+                'width' => 'calc(50% - 12px)',
+            ],
+        ]);
+    }
+}

--- a/src/widgets/combo/PartnoCombo.php
+++ b/src/widgets/combo/PartnoCombo.php
@@ -25,7 +25,7 @@ class PartnoCombo extends Combo
     public $url = '/stock/model/index';
 
     /** {@inheritdoc} */
-    public $_return = ['id'];
+    public $_return = ['id', 'warranty_months'];
 
     /** {@inheritdoc} */
     public $_rename = ['text' => 'partno'];


### PR DESCRIPTION
…ntpu automatically when part careate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `WarrantyColumn` class for enhanced data representation.
	- Added a `WarrantyMonthsRangeInput` widget for specifying warranty periods.
- **Enhancements**
	- Improved date and time formatting in the part grid view.
	- Enhanced select event handling in part form views.
	- Dynamic attribute binding for `auto-select-ancestors` in `StockLocationsListTreeSelect`.
- **Refactor**
	- Consolidated `prepareValue` method functionality in `ModelColumn`.
	- Removed `ModelColumn` usage in favor of `WarrantyColumn`.
	- Explicitly specified trait name in `PartSearch` class method declaration.
	- Adjusted `PartnoCombo` to include `warranty_months` in its return properties.
- **Style**
	- Minor formatting and indentation adjustments in various files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->