### PR TITLE
HP-1929: fix type error whena `location_type` is null

### DIFF
--- a/src/grid/ModelGridView.php
+++ b/src/grid/ModelGridView.php
@@ -116,7 +116,7 @@ class ModelGridView extends BoxedGridView
                 continue;
             }
             $location = $locations[$locationId];
-            $icon = $this->locationsProvider->getIcon($location['location_type']);
+            $icon = $this->locationsProvider->getIcon($location['location_type'] ?? '');
             $label = $this->locationsProvider->getLabel($location);
             $result[$key] = [
                 'attribute' => $key,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the handling of stock location types to prevent errors when no type is specified, now defaults to an empty string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->