### PR TITLE
HP-1581: fixed "explode(): Passing null to parameter #2 ($string) of type string is deprecated" error

### DIFF
--- a/src/widgets/StockLocationsListTreeSelect.php
+++ b/src/widgets/StockLocationsListTreeSelect.php
@@ -41,7 +41,7 @@ class StockLocationsListTreeSelect extends VueTreeSelectInput
     {
         $this->useStorage = !$this->hasModel();
         $this->value = $this->hasModel()
-            ? StringHelper::explode($this->model->{$this->attribute})
+            ? StringHelper::explode($this->model->{$this->attribute} ?? '')
             : $this->provider->getLocations();
 
         parent::init();


### PR DESCRIPTION
https://sentry.hiqdev.com/organizations/hiqdev/issues/57337/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved robustness of the `StockLocationsListTreeSelect` component to handle null values more effectively, preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->