### PR TITLE
HP-2099: use id and object name

### DIFF
--- a/src/repositories/DisposalRepository.php
+++ b/src/repositories/DisposalRepository.php
@@ -49,7 +49,6 @@ readonly class DisposalRepository
         $sortedStrings = [];
         foreach (array_keys($similarityScores) as $index) {
             $sortedStrings[$index] = $strings[$index];
-            var_dump($strings[$index]);
         }
 
         return $sortedStrings;

--- a/src/repositories/DisposalRepository.php
+++ b/src/repositories/DisposalRepository.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace hipanel\modules\stock\repositories;
 
@@ -18,7 +20,7 @@ readonly class DisposalRepository
         $devices = $this->getDevices();
         $deviceId2Location = array_filter(ArrayHelper::map($devices, 'id', 'bindings.location.switch'));
         if ($deviceLocation === null) {
-            return $devices;
+            return ArrayHelper::map($devices, 'id', 'name');
         }
 
         return $this->sortBySimilarity($deviceId2Location, $deviceLocation);
@@ -47,6 +49,7 @@ readonly class DisposalRepository
         $sortedStrings = [];
         foreach (array_keys($similarityScores) as $index) {
             $sortedStrings[$index] = $strings[$index];
+            var_dump($strings[$index]);
         }
 
         return $sortedStrings;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the device data retrieval method to return a more structured output, including only 'id' and 'name' for devices based on location.

- **Bug Fixes**
	- Adjusted the output of the device location search to improve data handling.

- **Chores**
	- Added debugging output to the sorting function for better visibility during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->