### PR TITLE
HP-2117: Allow '-' symbol in part serialno on /stock/part/replace page

### DIFF
--- a/src/models/Part.php
+++ b/src/models/Part.php
@@ -150,9 +150,9 @@ class Part extends \hipanel\base\Model
             [
                 ['serial'],
                 'match',
-                'pattern' => '/^[a-zA-Z0-9]+$/u',
+                'pattern' => '/^[a-zA-Z0-9-]+$/u',
                 'on' => 'replace',
-                'message' => Yii::t('hipanel:stock', 'The input format must match /^[a-zA-Z0-9]+$/'),
+                'message' => Yii::t('hipanel:stock', 'The input format must match /^[a-zA-Z0-9-]+$/'),
             ],
             [['disposal_id'], 'string', 'on' => 'replace'],
 

--- a/src/models/Part.php
+++ b/src/models/Part.php
@@ -150,9 +150,9 @@ class Part extends \hipanel\base\Model
             [
                 ['serial'],
                 'match',
-                'pattern' => '/^[a-zA-Z0-9-]+$/u',
+                'pattern' => '/^([a-zA-Z0-9-]+|_)$/u',
                 'on' => 'replace',
-                'message' => Yii::t('hipanel:stock', 'The input format must match /^[a-zA-Z0-9-]+$/'),
+                'message' => Yii::t('hipanel:stock', 'The input format must match /^[a-zA-Z0-9-]+$/ or the _ character, which will create a random serial.'),
             ],
             [['disposal_id'], 'string', 'on' => 'replace'],
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced validation for the `serial` attribute to accept hyphens and underscores, allowing for a broader range of valid serial numbers.

- **Bug Fixes**
	- Updated error message for `serial` attribute validation to reflect the new input format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->