### PR TITLE
HP-2081: fix OrdersCest::ensureICantCreateEmptyOrder Codeception test

### DIFF
--- a/tests/acceptance/manager/OrdersCest.php
+++ b/tests/acceptance/manager/OrdersCest.php
@@ -33,10 +33,10 @@ class OrdersCest
         $I->needPage(Url::to('@order/create'));
         $I->click('Save');
         $I->waitForPageUpdate();
-        $I->waitForText('# cannot be blank.');
-        $I->waitForText('Time cannot be blank.');
         $I->waitForText('Seller cannot be blank.');
         $I->waitForText('Buyer cannot be blank.');
+        $I->waitForText('# cannot be blank.');
+        $I->waitForText('Order cannot be blank.');
     }
 
     public function ensureICanCreateOrder(Manager $I): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated validation message for creating empty orders to reflect the correct error: "Order cannot be blank."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->