### PR TITLE
HP-2320: add logic for `type` and `move_type` input when move

### DIFF
--- a/src/models/Part.php
+++ b/src/models/Part.php
@@ -139,7 +139,7 @@ class Part extends \hipanel\base\Model
             [['serials'], 'unique', 'on' => ['create', 'copy']],
 
             // Move by one
-            [['id', 'dst_id', 'src_id', 'partno', 'serial'], 'required', 'on' => 'move-by-one'],
+            [['id', 'dst_id', 'src_id', 'partno', 'serial', 'move_type'], 'required', 'on' => 'move-by-one'],
 
             // Trash
             [['id', 'dst_id', 'src_id', 'partno', 'serial', 'move_descr'], 'required', 'on' => 'trash'],

--- a/src/views/part/_move.php
+++ b/src/views/part/_move.php
@@ -7,6 +7,7 @@
 use hipanel\modules\stock\models\Part;
 use hipanel\modules\stock\widgets\combo\DestinationCombo;
 use hipanel\modules\stock\widgets\combo\SourceCombo;
+use hipanel\modules\stock\widgets\MoveTypeDropDownList;
 use hipanel\widgets\Box;
 use hipanel\widgets\ArraySpoiler;
 use yii\helpers\Html;
@@ -52,7 +53,7 @@ use yii\helpers\Html;
                             ]) ?>
                         </div>
                         <div class="col-lg-4">
-                            <?= $form->field($model, "[$src_id]type")->dropDownList($types, ['id' => "$src_id-type-" . uniqid()]) ?>
+                            <?= $form->field($model, "[$src_id]type")->widget(MoveTypeDropDownList::class, ['items' => $types, 'id' => "$src_id-type-" . uniqid()]) ?>
                         </div>
                     </div>
                     <div class="row">

--- a/src/views/part/moveByOne.php
+++ b/src/views/part/moveByOne.php
@@ -5,11 +5,19 @@ use hipanel\modules\stock\widgets\combo\DestinationCombo;
 use hipanel\modules\stock\widgets\combo\RmaDestinationCombo;
 use hipanel\modules\stock\widgets\combo\PartnoCombo;
 use hipanel\modules\stock\widgets\combo\SourceCombo;
+use hipanel\modules\stock\widgets\MoveTypeDropDownList;
 use hipanel\widgets\Box;
 use hipanel\widgets\DynamicFormWidget;
 use yii\bootstrap\ActiveForm;
 use yii\helpers\Html;
 use yii\helpers\StringHelper;
+
+/**
+ * @var \yii\web\View $this
+ * @var \hipanel\modules\stock\models\Part[] $models
+ * @var array $remotehands
+ * @var array $types
+ */
 
 $scenario = $this->context->action->scenario;
 $this->title = StringHelper::startsWith($this->context->action->id, 'move-by-one') ? Yii::t('hipanel:stock', 'Move by one') : Yii::t('hipanel:stock', 'RMA');
@@ -94,7 +102,7 @@ $this->params['breadcrumbs'][] = $this->title;
                         </div>
                         <div class="col-md-6">
                             <?php $model->dst_id = null ?>
-                            <?php if (strstr($this->context->action->id, 'rma') !== false) : ?>
+                            <?php if (str_contains($this->context->action->id, 'rma')) : ?>
                                 <?= $form->field($model, "[$i]dst_id")->widget(RmaDestinationCombo::class) ?>
                             <?php else : ?>
                                 <?= $form->field($model, "[$i]dst_id")->widget(DestinationCombo::class) ?>
@@ -105,7 +113,7 @@ $this->params['breadcrumbs'][] = $this->title;
 
                     <div class="row">
                         <div class="col-md-6">
-                            <?= $form->field($model, "[$i]move_type")->dropDownList($types) ?>
+                            <?= $form->field($model, "[$i]move_type")->widget(MoveTypeDropDownList::class, ['items' => $types]) ?>
                         </div>
                         <div class="col-md-6">
                             <?= $form->field($model, "[$i]remotehands")->dropDownList($remotehands) ?>

--- a/src/widgets/MoveTypeDropDownList.php
+++ b/src/widgets/MoveTypeDropDownList.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace hipanel\modules\stock\widgets;
+
+use yii\base\InvalidConfigException;
+use yii\helpers\ArrayHelper;
+use yii\helpers\Html;
+use yii\widgets\InputWidget;
+
+class MoveTypeDropDownList extends InputWidget
+{
+    public array $items = [];
+
+    public function init(): void
+    {
+        parent::init();
+        if (!$this->hasModel()) {
+            throw new InvalidConfigException("Model is required");
+        }
+        $id = ArrayHelper::getValue($this->options, 'id');
+        $this->view->registerJs(/** @lang JavaScript */ <<<JS
+(($) => {
+    "use strict";
+    $("#$id").val("");
+    const dstSelect = $("#$id").parents(".box").find("select[id*=\"-dst_id\"]");
+    if (dstSelect.length) {
+      dstSelect.on("change", function () {
+        const dstType = $(this).find("option:selected").data("type");
+        if (["chwbox", "stock"].includes(dstType)) {
+            $("#$id").val("stock");
+        } else if ([
+          "ahcloud",
+          "avdsnode",
+          "cloudstorage",
+          "delivery",
+          "dedicated",
+          "system",
+          "nic",
+          "cdnstat",
+          "remote",
+          "reserved",
+          "suspended",
+          "termination",
+          "utilization",
+          "unused",
+          "cdnv2",
+          "vdsmaster",
+          "cloudservers",
+        ].includes(dstType)) {
+            $("#$id").val("install");
+        } else {
+            $("#$id").val("");
+        }
+      });
+    }
+})(jQuery);
+JS
+        );
+    }
+
+    public function run()
+    {
+        return Html::activeDropDownList($this->model, $this->attribute, $this->items, ArrayHelper::merge($this->options, ['prompt' => '']));
+    }
+}

--- a/src/widgets/combo/DestinationCombo.php
+++ b/src/widgets/combo/DestinationCombo.php
@@ -12,6 +12,7 @@
 namespace hipanel\modules\stock\widgets\combo;
 
 use hiqdev\combo\Combo;
+use yii\web\JsExpression;
 
 class DestinationCombo extends Combo
 {
@@ -25,10 +26,28 @@ class DestinationCombo extends Combo
     public $url = '/stock/move/directions-list';
 
     /** {@inheritdoc} */
-    public $_return = ['id'];
+    public $_return = ['id', 'type'];
 
     /** {@inheritdoc} */
     public $_rename = ['text' => 'name'];
 
     public $_primaryFilter = 'name_like';
+
+    public function getPluginOptions($options = [])
+    {
+        return parent::getPluginOptions([
+            'select2Options' => [
+                'templateSelection' => new JsExpression(/** @lang JavaScript */ "function (data, container) {
+                    if ('element' in data) {
+                        $(data.element).attr('data-type', data?.type);
+                    }
+
+                    return data.text;
+                }"),
+                'escapeMarkup' => new JsExpression('function (markup) {
+                    return markup; // Allows HTML
+                }'),
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced part movement functionality with improved type selection
  - Added more robust validation for move-by-one operations

- **Improvements**
  - Updated destination combo to return additional type information
  - Introduced a new specialized dropdown widget for move types
  - Improved code readability with modern string checking methods

- **Technical Updates**
  - Refined validation rules for part movements
  - Enhanced form field rendering for move operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->