### PR TITLE
HP-2422: hide price column if has not `part.create` because a situati…

### DIFF
--- a/src/grid/ObjectPartsGridView.php
+++ b/src/grid/ObjectPartsGridView.php
@@ -86,7 +86,7 @@ class ObjectPartsGridView extends BoxedGridView
                 'value' => fn(Part $part): ?string => !empty($part->price) ? $this->formatter->asCurrency($part->price,
                     $part->currency) : null,
                 'filter' => $this->dropdownFor('currency'),
-                'visible' => $user->can('move.read-all'),
+                'visible' => $user->can('move.read-all') && $user->can('part.create'),
             ],
             'move_time' => [
                 'contentOptions' => ['style' => 'width: 20%'],


### PR DESCRIPTION
…on has arisen where the currency does not come from the API due to the lack of this permission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced access control for pricing information so that it now displays only for users with the proper permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->