### PR TITLE
HP-2580: add `in-sale-buyer` column to PartGridView and update part v…

### DIFF
--- a/src/grid/PartGridView.php
+++ b/src/grid/PartGridView.php
@@ -254,6 +254,15 @@ class PartGridView extends BoxedGridView
                 'attribute' => 'buyer',
                 'footer' => '<b>' . Yii::t('hipanel:stock', 'TOTAL on screen') . '</b>',
             ],
+            'in-sale-buyer' => [
+                'attribute' => 'sale.buyer',
+                'format' => 'raw',
+                'value' => fn(Part $model): ?string => $model->isRelationPopulated('sale') && $model->sale->buyer ? Html::a(
+                    Html::encode($model->sale->buyer),
+                    ['@client/view', 'id' => $model->sale->buyer_id]
+                ) : null,
+                'visible' => Yii::$app->user->can('access-subclients'),
+            ],
             'selling_price' => [
                 'format' => 'raw',
                 'filterAttribute' => 'selling_currency',

--- a/src/views/part/view.php
+++ b/src/views/part/view.php
@@ -66,6 +66,7 @@ $this->params['breadcrumbs'][] = Yii::t('hipanel', $this->title);
                                     'place',
                                     'company',
                                     'reserve',
+                                    'in-sale-buyer',
                                     'first_move',
                                     'sale',
                                 ],


### PR DESCRIPTION
…iew columns to show `buyer` link in part detailed view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Buyer" column to the part grid, showing the buyer associated with a sale when applicable.
  * The buyer's name is displayed as a clickable link to their profile, visible only to users with appropriate permissions.
  * Included the buyer information in the detailed view of a part.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->