### PR TITLE
HP-2655: extend MoveTypeDropDownList logic to handle cases with 'SW' …

### DIFF
--- a/src/widgets/MoveTypeDropDownList.php
+++ b/src/widgets/MoveTypeDropDownList.php
@@ -49,7 +49,7 @@ class MoveTypeDropDownList extends InputWidget
           "cdnv2",
           "vdsmaster",
           "cloudservers",
-        ].includes(dstType)) {
+        ].includes(dstType) || dstName.startsWith('SW')) {
             $("#$id").val("install");
         } else {
             $("#$id").val("");


### PR DESCRIPTION
…as destination name prefix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated move type selection behavior: choosing a destination whose name starts with “SW” now automatically triggers the installation flow, consistent with other supported destination types.
  * Delivers a smoother, more predictable experience by reducing manual steps for certain destinations and aligning handling across similar options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->