### PR TITLE
HQD-133: Replace Stock type and category enums with value-object classes

### DIFF
--- a/src/enums/StockLocationCategory.php
+++ b/src/enums/StockLocationCategory.php
@@ -2,14 +2,26 @@
 
 namespace hipanel\modules\stock\enums;
 
-enum StockLocationCategory: string
+final class StockLocationCategory
 {
-    case STOCK = 'stock';
-    case STOCK_GROUP = 'stock_group';
-    case CHWBOX = 'chwbox';
-    case CHWBOX_GROUP = 'chwbox_group';
-    case LOCATION = 'location';
-    case LOCATION_GROUP = 'location_group';
-    case ALIAS_GROUP = 'alias_group';
-    case ALIAS_GROUP_BY_STOCK_STATE = 'alias_group_by_stock_state';
+    public const string STOCK = 'stock';
+    public const string STOCK_GROUP = 'stock_group';
+    public const string CHWBOX = 'chwbox';
+    public const string CHWBOX_GROUP = 'chwbox_group';
+    public const string LOCATION = 'location';
+    public const string LOCATION_GROUP = 'location_group';
+    public const string ALIAS_GROUP = 'alias_group';
+    public const string ALIAS_GROUP_BY_STOCK_STATE = 'alias_group_by_stock_state';
+
+    private(set) string $value;
+
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public static function from(string $value): self
+    {
+        return new self($value);
+    }
 }

--- a/src/enums/StockLocationType.php
+++ b/src/enums/StockLocationType.php
@@ -2,28 +2,40 @@
 
 namespace hipanel\modules\stock\enums;
 
-enum StockLocationType: string
+final class StockLocationType
 {
-    case ALIAS = 'alias';
-    case BUILDING = 'building';
-    case CAGE = 'cage';
-    case CHWBOX = 'chwbox';
-    case CHWBOX_GROUP = 'chwbox_group';
-    case DC = 'dc';
-    case FOR_TEST = 'for-test';
-    case LOCATION = 'location';
-    case RACK = 'rack';
-    case RMA = 'rma';
-    case STOCK = 'stock';
-    case STOCK_GROUP = 'stock_group';
-    case USED = 'used';
-    case DELETED = 'deleted';
-    case SOLD = 'sold';
-    case SUPPLIER = 'supplier';
-    case TRASH = 'trash';
-    case ALIAS_GROUP_USED = 'alias_group_used';
-    case ALIAS_GROUP_RMA = 'alias_group_rma';
-    case ALIAS_GROUP_FOR_TEST = 'alias_group_for-test';
-    case ALIAS_GROUP_STOCK = 'alias_group_stock';
-    case DISPOSAL = 'disposal';
+    public const string ALIAS = 'alias';
+    public const string BUILDING = 'building';
+    public const string CAGE = 'cage';
+    public const string CHWBOX = 'chwbox';
+    public const string CHWBOX_GROUP = 'chwbox_group';
+    public const string DC = 'dc';
+    public const string FOR_TEST = 'for-test';
+    public const string LOCATION = 'location';
+    public const string RACK = 'rack';
+    public const string RMA = 'rma';
+    public const string STOCK = 'stock';
+    public const string STOCK_GROUP = 'stock_group';
+    public const string USED = 'used';
+    public const string DELETED = 'deleted';
+    public const string SOLD = 'sold';
+    public const string SUPPLIER = 'supplier';
+    public const string TRASH = 'trash';
+    public const string ALIAS_GROUP_USED = 'alias_group_used';
+    public const string ALIAS_GROUP_RMA = 'alias_group_rma';
+    public const string ALIAS_GROUP_FOR_TEST = 'alias_group_for-test';
+    public const string ALIAS_GROUP_STOCK = 'alias_group_stock';
+    public const string DISPOSAL = 'disposal';
+
+    private(set) string $value;
+
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public static function from(string $value): self
+    {
+        return new self($value);
+    }
 }

--- a/src/models/VO/LocationItem.php
+++ b/src/models/VO/LocationItem.php
@@ -47,14 +47,14 @@ final readonly class LocationItem
             return $this->name;
         }
 
-        return match ($this->category) {
+        return match ($this->category->value) {
             StockLocationCategory::STOCK => implode(':', [$this->type->value, $this->name]),
             StockLocationCategory::STOCK_GROUP => $this->name,
             StockLocationCategory::CHWBOX_GROUP => $this->name === $this->customer
                 ? $this->name
                 : implode('/', [StringHelper::truncate($this->customer, 7), $this->name]),
             StockLocationCategory::CHWBOX => $this->id,
-            default => ($this->type === StockLocationType::CHWBOX_GROUP) ? $this->customer : $this->id,
+            default => ($this->type->value === StockLocationType::CHWBOX_GROUP) ? $this->customer : $this->id,
         };
     }
 
@@ -67,7 +67,7 @@ final readonly class LocationItem
 
     private function getIcon(): string
     {
-        return match ($this->type) {
+        return match ($this->type->value) {
             StockLocationType::CHWBOX => 'fa-user',
             StockLocationType::CHWBOX_GROUP => 'fa-users',
             StockLocationType::DELETED => 'fa-ban',

--- a/src/repositories/StockLocationsRepository.php
+++ b/src/repositories/StockLocationsRepository.php
@@ -9,7 +9,7 @@ use yii\web\User;
 
 class StockLocationsRepository
 {
-    private const string CACHE_KEY = 'stock-locations-objects';
+    private const string CACHE_KEY = 'stock-locations-objects-cache-key';
     private const int CACHE_DURATION = 60 * 60 * 24; // 1 day
 
     public function __construct(


### PR DESCRIPTION
Prevents ValueError when DB returns a location type/category not yet defined in code. Unknown values are preserved as-is and accessible via ->value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture for stock location handling to enhance code maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiqdev/hipanel-module-stock/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->