### PR TITLE
HQD-306: Add Playwright coverage for bulk part deletion and erasing

### DIFF
--- a/tests/playwright/e2e/manager/part/part-bulk-erase.spec.ts
+++ b/tests/playwright/e2e/manager/part/part-bulk-erase.spec.ts
@@ -1,0 +1,45 @@
+import { test } from "@hipanel-core/fixtures";
+import PartCreateView from "@hipanel-module-stock/page/PartCreateView";
+import PartIndexView from "@hipanel-module-stock/page/PartIndexView";
+import { UniqueId } from "@hipanel-core/shared/lib";
+
+function getPartData(serial: string) {
+  return {
+    partno: "EPYC 7402P",
+    src_id: "TEST-DS-01",
+    dst_id: "TEST-DS-02",
+    serials: serial,
+    move_descr: "MG TEST MOVE",
+    price: 200,
+    currency: "$",
+    company_id: "Other",
+  };
+}
+
+test.describe("Part Bulk Erase", () => {
+  // HQD-306: bulk-erasing filtered, previously deleted parts got stuck on an infinite loading modal.
+  test("Ensure deleted parts can be bulk erased after filtering @hipanel-module-stock @manager", async ({ managerPage }) => {
+    // Part creation plus two bulk round-trips (mark deleted, then erase) is slow on a loaded dump env
+    // -- a full run without the bug reproducing already takes ~2.5 minutes.
+    test.setTimeout(300_000);
+
+    const serialPrefix = UniqueId.generate("MG_TEST_ERASE_");
+    const partCreateView = new PartCreateView(managerPage);
+    const partIndexView = new PartIndexView(managerPage);
+
+    await partCreateView.navigate();
+    await partCreateView.fillPartFields(getPartData(`${serialPrefix}-1`));
+    await partCreateView.addPart();
+    await partCreateView.fillPartFields(getPartData(`${serialPrefix}-2`), 1);
+    await partCreateView.save();
+
+    await partIndexView.seePartWasCreated();
+
+    await partIndexView.navigateCommon();
+    await partIndexView.applyFilters([{ name: "serial_ilike", value: serialPrefix }]);
+    await partIndexView.bulkMarkAsDeleted(2);
+
+    await partIndexView.filterDeletedBySerial(serialPrefix);
+    await partIndexView.bulkErase(2);
+  });
+});

--- a/tests/playwright/e2e/manager/part/part-create.spec.ts
+++ b/tests/playwright/e2e/manager/part/part-create.spec.ts
@@ -3,7 +3,6 @@ import { expect } from "@playwright/test";
 import PartCreateView from "@hipanel-module-stock/page/PartCreateView";
 import { UniqueId } from "@hipanel-core/shared/lib";
 import PartIndexView from "@hipanel-module-stock/page/PartIndexView";
-import PartView from "@hipanel-module-stock/page/PartView";
 
 function getPartData() {
   return {
@@ -85,33 +84,5 @@ test.describe("Part Management", () => {
     await partView.save();
 
     await partIndexView.seePartWasCreated();
-  });
-
-  test("Ensure a part can be created and then marked as deleted @hipanel-module-stock @manager", async ({ managerPage }) => {
-    const partCreateView = new PartCreateView(managerPage);
-    const partIndexView = new PartIndexView(managerPage);
-
-    await partCreateView.navigate();
-    await partCreateView.fillPartFields(getPartData());
-    await partCreateView.save();
-
-    await partIndexView.seePartWasCreated();
-
-    const partView = new PartView(managerPage);
-    await partView.markPartAsDeleted();
-  });
-
-  test("Ensure a part can be created and then erased @hipanel-module-stock @manager", async ({ managerPage }) => {
-    const partCreateView = new PartCreateView(managerPage);
-    const partIndexView = new PartIndexView(managerPage);
-
-    await partCreateView.navigate();
-    await partCreateView.fillPartFields(getPartData());
-    await partCreateView.save();
-
-    await partIndexView.seePartWasCreated();
-
-    const partView = new PartView(managerPage);
-    await partView.erasePart();
   });
 });

--- a/tests/playwright/e2e/manager/part/part-delete.spec.ts
+++ b/tests/playwright/e2e/manager/part/part-delete.spec.ts
@@ -1,0 +1,48 @@
+import { test } from "@hipanel-core/fixtures";
+import PartCreateView from "@hipanel-module-stock/page/PartCreateView";
+import { UniqueId } from "@hipanel-core/shared/lib";
+import PartIndexView from "@hipanel-module-stock/page/PartIndexView";
+import PartView from "@hipanel-module-stock/page/PartView";
+
+function getPartData() {
+  return {
+    partno: "EPYC 7402P",
+    src_id: "TEST-DS-01",
+    dst_id: "TEST-DS-02",
+    serials: UniqueId.generate(`MG_TEST_PART`),
+    move_descr: "MG TEST MOVE",
+    price: 200,
+    currency: "$",
+    company_id: "Other",
+  };
+}
+
+test.describe("Part Deletion", () => {
+  test("Ensure a part can be created and then marked as deleted @hipanel-module-stock @manager", async ({ managerPage }) => {
+    const partCreateView = new PartCreateView(managerPage);
+    const partIndexView = new PartIndexView(managerPage);
+
+    await partCreateView.navigate();
+    await partCreateView.fillPartFields(getPartData());
+    await partCreateView.save();
+
+    await partIndexView.seePartWasCreated();
+
+    const partView = new PartView(managerPage);
+    await partView.markPartAsDeleted();
+  });
+
+  test("Ensure a part can be created and then erased @hipanel-module-stock @manager", async ({ managerPage }) => {
+    const partCreateView = new PartCreateView(managerPage);
+    const partIndexView = new PartIndexView(managerPage);
+
+    await partCreateView.navigate();
+    await partCreateView.fillPartFields(getPartData());
+    await partCreateView.save();
+
+    await partIndexView.seePartWasCreated();
+
+    const partView = new PartView(managerPage);
+    await partView.erasePart();
+  });
+});

--- a/tests/playwright/page/PartIndexView.ts
+++ b/tests/playwright/page/PartIndexView.ts
@@ -1,5 +1,6 @@
 import { expect, Page } from "@playwright/test";
 import Index from "@hipanel-core/page/Index";
+import { Modal } from "@hipanel-core/shared/ui/components";
 
 export default class PartIndexView {
   private index: Index;
@@ -24,6 +25,14 @@ export default class PartIndexView {
     await this.index.advancedSearch.applyFilter("serial_ilike", serial);
   }
 
+  async filterDeletedBySerial(serial: string) {
+    // Yii renders the "show_deleted" checkbox alongside a same-named hidden
+    // input, so the generic name-based filter locator matches two elements.
+    await this.index.advancedSearch.setFilter("serial_ilike", serial);
+    await this.page.getByLabel("Show Deleted Parts").check();
+    await this.index.submitSearchButton();
+  }
+
   async selectPartsToReplace(count: number) {
     await this.selectRows(count);
     await this.index.clickDropdownBulkButton("Bulk actions", "Replace");
@@ -46,6 +55,28 @@ export default class PartIndexView {
 
     this.page.on("dialog", async dialog => await dialog.accept());
     await this.index.hasNotification("Part has been deleted");
+  }
+
+  async bulkMarkAsDeleted(count: number) {
+    await this.selectRows(count);
+    await this.index.clickDropdownBulkButton("Bulk actions", "Mark as Deleted");
+
+    await this.confirmBulkModalAction("Delete");
+    await this.index.hasNotification("Part has been deleted");
+  }
+
+  async bulkErase(count: number) {
+    await this.selectRows(count);
+    await this.index.clickDropdownBulkButton("Bulk actions", "Erase");
+
+    await this.confirmBulkModalAction("Erase");
+    await this.index.hasNotification("Part has been erased");
+  }
+
+  private async confirmBulkModalAction(buttonText: string) {
+    const modal = new Modal(this.page);
+    await modal.waitForOpen();
+    await modal.clickButton(buttonText);
   }
 
   async chooseNumberRowOnTable(number: number) {


### PR DESCRIPTION
Add a bulk-erase test (create parts, bulk mark as deleted, filter, bulk erase) covering the index-page flow from HQD-306, and extend PartIndexView with bulkMarkAsDeleted/bulkErase/filterDeletedBySerial helpers to support it.

Also split the single-item "mark as deleted"/"erase" tests out of part-create.spec.ts into their own part-delete.spec.ts, since they exercise the part detail page's delete/erase flow rather than creation and were easy to miss there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for creating, deleting, filtering, and erasing parts.
  * Added coverage for bulk deletion and bulk erasure of filtered, previously deleted parts.
  * Removed redundant part deletion scenarios from the creation test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->